### PR TITLE
added SELENIUM_NO_NATIVE_EVENTS option

### DIFF
--- a/selenium_factory/selenium_factory.py
+++ b/selenium_factory/selenium_factory.py
@@ -255,6 +255,9 @@ class SeleniumFactory:
                 else:
                     desired_capabilities['time-zone'] = 'Pacific'
 
+            if 'SELENIUM_NO_NATIVE_EVENTS' in os.environ:
+                desired_capabilities['nativeEvents'] = False
+
             command_executor = "http://%s:%s@%s:%s/wd/hub" % (parse.get_user_name(),
                                                               parse.get_access_key(),
                                                               SELENIUM_HOST,


### PR DESCRIPTION
Running SauceLabs with IE seems to have a number of bugs -- having the ability to turn off native events in the factory would help us get past these problems.  
